### PR TITLE
Support SixLabors.ImageSharp v3+ on .NET8

### DIFF
--- a/src/OpenMacroBoard.SDK/OpenMacroBoard.SDK.csproj
+++ b/src/OpenMacroBoard.SDK/OpenMacroBoard.SDK.csproj
@@ -18,8 +18,14 @@
   <Import Project="..\..\..\analyzers.targets" />
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
     <None Include="icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.13" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">

--- a/src/OpenMacroBoard.Tests/OpenMacroBoard.Tests.csproj
+++ b/src/OpenMacroBoard.Tests/OpenMacroBoard.Tests.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="AwesomeAssertions" Version="9.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
     <PackageReference Include="Verify.Xunit" Version="14.12.0" />
     <PackageReference Include="System.Reactive" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -34,6 +33,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OpenMacroBoard.VirtualBoard/DecoratedVirtualBoard.cs
+++ b/src/OpenMacroBoard.VirtualBoard/DecoratedVirtualBoard.cs
@@ -40,6 +40,9 @@ namespace OpenMacroBoard.VirtualBoard
                 .GetExecutingAssembly()
                 .GetManifestResourceStream("OpenMacroBoard.VirtualBoard.OpenMacroBoard-Logo.png");
 
+            if (logoStream == null)
+                throw new ArgumentNullException();
+
             using var logo = Image.Load(logoStream);
             nakedBoard.DrawFullScreenBitmap(logo);
 


### PR DESCRIPTION
Added conditional includes for SixLabors so this library can be built using v3 of the ImageSharp library.